### PR TITLE
general lint fixes

### DIFF
--- a/app/controller/act.go
+++ b/app/controller/act.go
@@ -16,7 +16,7 @@ import (
 
 func Act(key string, rc *fasthttp.RequestCtx, f func(as *app.State, ps *cutil.PageState) (string, error)) {
 	as := _currentAppState
-	ps := cutil.LoadPageState(as, rc, key, _currentAppRootLogger)
+	ps := cutil.LoadPageState(rc, key, _currentAppRootLogger)
 	if err := initAppRequest(as, ps); err != nil {
 		ps.Logger.Warnf("%+v", err)
 	}
@@ -25,7 +25,7 @@ func Act(key string, rc *fasthttp.RequestCtx, f func(as *app.State, ps *cutil.Pa
 
 func ActSite(key string, rc *fasthttp.RequestCtx, f func(as *app.State, ps *cutil.PageState) (string, error)) {
 	as := _currentSiteState
-	ps := cutil.LoadPageState(as, rc, key, _currentSiteRootLogger)
+	ps := cutil.LoadPageState(rc, key, _currentSiteRootLogger)
 	ps.Menu = site.Menu(ps.Context, as, ps.Profile, ps.Logger)
 	if err := initSiteRequest(as, ps); err != nil {
 		ps.Logger.Warnf("%+v", err)
@@ -33,8 +33,14 @@ func ActSite(key string, rc *fasthttp.RequestCtx, f func(as *app.State, ps *cuti
 	actComplete(key, as, ps, rc, f)
 }
 
-func actComplete(key string, as *app.State, ps *cutil.PageState, rc *fasthttp.RequestCtx, f func(as *app.State, ps *cutil.PageState) (string, error)) {
-	err := ps.Clean(rc, as)
+func actComplete(
+	key string,
+	as *app.State,
+	ps *cutil.PageState,
+	rc *fasthttp.RequestCtx,
+	f func(as *app.State, ps *cutil.PageState) (string, error),
+) {
+	err := ps.Clean(as)
 	if err != nil {
 		ps.Logger.Warnf("error while cleaning request, somehow: %+v", err)
 	}

--- a/app/controller/cmenu/docs.go
+++ b/app/controller/cmenu/docs.go
@@ -1,4 +1,6 @@
 // Content managed by Project Forge, see [projectforge.md] for details.
+//
+//nolint:revive
 package cmenu
 
 import (

--- a/app/controller/cmenu/menu.go
+++ b/app/controller/cmenu/menu.go
@@ -1,4 +1,6 @@
 // Content managed by Project Forge, see [projectforge.md] for details.
+//
+//nolint:revive
 package cmenu
 
 import (

--- a/app/controller/cutil/page.go
+++ b/app/controller/cutil/page.go
@@ -88,7 +88,7 @@ func (p *PageState) Username() string {
 	return p.Profile.Name
 }
 
-func (p *PageState) Clean(rc *fasthttp.RequestCtx, as *app.State) error {
+func (p *PageState) Clean(as *app.State) error {
 	if p.Profile != nil && p.Profile.Theme == "" {
 		p.Profile.Theme = theme.ThemeDefault.Key
 	}

--- a/app/controller/cutil/session.go
+++ b/app/controller/cutil/session.go
@@ -2,11 +2,8 @@
 package cutil
 
 import (
-	"context"
-
 	"github.com/valyala/fasthttp"
 
-	"projectforge.dev/projectforge/app"
 	"projectforge.dev/projectforge/app/controller/csession"
 	"projectforge.dev/projectforge/app/lib/telemetry"
 	"projectforge.dev/projectforge/app/lib/telemetry/httpmetrics"
@@ -16,13 +13,13 @@ import (
 
 var initialIcons = []string{"searchbox"}
 
-func LoadPageState(as *app.State, rc *fasthttp.RequestCtx, key string, logger util.Logger) *PageState {
+func LoadPageState(rc *fasthttp.RequestCtx, key string, logger util.Logger) *PageState {
 	parentCtx, logger := httpmetrics.ExtractHeaders(rc, logger)
 	ctx, span, logger := telemetry.StartSpan(parentCtx, "http:"+key, logger)
 	span.Attribute("path", string(rc.Request.URI().Path()))
 	httpmetrics.InjectHTTP(rc, span)
 
-	session, flashes, prof := loadSession(ctx, as, rc, logger)
+	session, flashes, prof := loadSession(rc, logger)
 	params := ParamSetFromRequest(rc)
 
 	return &PageState{
@@ -32,7 +29,7 @@ func LoadPageState(as *app.State, rc *fasthttp.RequestCtx, key string, logger ut
 	}
 }
 
-func loadSession(ctx context.Context, as *app.State, rc *fasthttp.RequestCtx, logger util.Logger) (util.ValueMap, []string, *user.Profile) {
+func loadSession(rc *fasthttp.RequestCtx, logger util.Logger) (util.ValueMap, []string, *user.Profile) {
 	sessionBytes := rc.Request.Header.Cookie(util.AppKey)
 	session := util.ValueMap{}
 	if len(sessionBytes) > 0 {

--- a/app/controller/state.go
+++ b/app/controller/state.go
@@ -42,7 +42,7 @@ func handleError(key string, as *app.State, ps *cutil.PageState, rc *fasthttp.Re
 		ps.Breadcrumbs = bc
 	}
 
-	if cleanErr := ps.Clean(rc, as); cleanErr != nil {
+	if cleanErr := ps.Clean(as); cleanErr != nil {
 		ps.Logger.Error(cleanErr)
 		msg := fmt.Sprintf("error while cleaning request: %+v", cleanErr)
 		ps.Logger.Error(msg)


### PR DESCRIPTION
Some lint fixes. Before removing unused parameters I checked all (most?) of our other apps to ensure they aren't utilized. In cases where they were, I slapped `//nolint:revive` on the package so the linter ignores it. Lmk if I missed anything!